### PR TITLE
Make User List AutoComplete-able

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -23,13 +23,14 @@ const gameState = {
 
 const defaultCommand = "/game record leaderboard: " + LEADERBOARD_NAME + " result:";
 
+let userNameToID = {};
 const userIds = (async () => {
   let data = [];
   try {
     data = await getUsers(LEADERBOARD_NAME);
   } catch (ex) {
-    // Simulate network loading time, 1.5 seconds
-    await new Promise(sleep => setTimeout(sleep, 1500));
+    // Simulate network loading time, .75 seconds
+    await new Promise(sleep => setTimeout(sleep, 750));
 
     // Makes it possible to test changes locally before pushing to main branch
     data = [
@@ -41,6 +42,9 @@ const userIds = (async () => {
     ];
   }
   UserSort(data);
+  data.forEach(dataItem => {
+    userNameToID[dataItem[1]] = dataItem[0];
+  });
   BuildHtmlLists(data);
   return data;
 })();
@@ -62,7 +66,7 @@ function UserSort(userIdData) {
   userIdData = userIdData.unshift(["TagMe", "(New Competitor)"]);
 }
 
-const list = document.querySelectorAll("[name='playerlist']");
+const searchableList = document.getElementById("searchableUsers");
 
 function BuildHtmlLists(userIdData) {
   userIdData.forEach((item) => {
@@ -70,13 +74,8 @@ function BuildHtmlLists(userIdData) {
     option.value = item[1];
     option.textContent = item[1];
     option.setAttribute("data-userid", item[0]);
-    let option2 = option.cloneNode(true);
-    let option3 = option.cloneNode(true);
-    let option4 = option.cloneNode(true);
-    list[0].appendChild(option);
-    list[1].appendChild(option2);
-    list[2].appendChild(option3);
-    list[3].appendChild(option4);
+
+    searchableList.appendChild(option);
   });
 
   document.getElementById("usersNotYetLoaded").style.display = "none";
@@ -91,17 +90,17 @@ function updateState() {
     document.getElementById("placement3"),
     document.getElementById("placement4"),
   ];
-  let userIDs = [
-    places[0].nextElementSibling.selectedOptions[0].getAttribute("data-userid"),
-    places[1].nextElementSibling.selectedOptions[0].getAttribute("data-userid"),
-    places[2].nextElementSibling.selectedOptions[0].getAttribute("data-userid"),
-    places[3].nextElementSibling.selectedOptions[0].getAttribute("data-userid"),
-  ];
   let userNames = [
-    places[0].nextElementSibling.selectedOptions[0].value,
-    places[1].nextElementSibling.selectedOptions[0].value,
-    places[2].nextElementSibling.selectedOptions[0].value,
-    places[3].nextElementSibling.selectedOptions[0].value,
+    places[0].nextElementSibling.value,
+    places[1].nextElementSibling.value,
+    places[2].nextElementSibling.value,
+    places[3].nextElementSibling.value,
+  ];
+  let userIDs = [
+    userNameToID[userNames[0]],
+    userNameToID[userNames[1]],
+    userNameToID[userNames[2]],
+    userNameToID[userNames[3]],
   ];
   Object.assign(gameState, {
     1: {

--- a/mgsr/index.html
+++ b/mgsr/index.html
@@ -31,9 +31,7 @@
                     <option value="3">3</option>
                     <option value="4">4</option>
                 </select>
-                <select  name="playerlist" list="players" id="firstplace">
-                    <option value="none" selected disabled hidden>Select a player</option>
-                </select>
+                <input list="searchableUsers" id="firstplace" placeholder="Select a player" />
             </div>
                 <br>
             <div id="2" onchange="updateState()">
@@ -45,9 +43,7 @@
                     <option value="3">3</option>
                     <option value="4">4</option>
                 </select>
-                <select  name="playerlist" list="players" id="secondplace">
-                    <option value="none" selected disabled hidden>Select a player</option>
-                </select>
+                <input list="searchableUsers" id="secondplace" placeholder="Select a player" />
             </div>
                 <br>
             <div id="3" onchange="updateState()">
@@ -59,9 +55,7 @@
                     <option value="3">3</option>
                     <option value="4">4</option>
                 </select>
-                <select  name="playerlist" list="players" id="thirdplace">
-                    <option value="none" selected disabled hidden>(None)</option>
-                </select>
+                <input list="searchableUsers" id="thirdplace" placeholder="(None)" />
             </div>
                 <br>
             <div id="4" onchange="updateState()">
@@ -73,16 +67,10 @@
                     <option value="3">3</option>
                     <option value="4">4</option>
                 </select>
-                <select  name="playerlist" list="players" id="fourthplace">
-                    <option value="none" selected disabled hidden>(None)</option>
-                </select>
+                <input list="searchableUsers" id="fourthplace" placeholder="(None)" />
             </div>
             
-            <datalist id="placements">
-              <option value="1">
-              <option value="2">
-              <option value="3">
-              <option value="4">
+            <datalist id="searchableUsers">
             </datalist>
 
         </form>

--- a/pats/index.html
+++ b/pats/index.html
@@ -31,9 +31,7 @@
                     <option value="3">3</option>
                     <option value="4">4</option>
                 </select>
-                <select  name="playerlist" list="players" id="firstplace">
-                    <option value="none" selected disabled hidden>Select a player</option>
-                </select>
+                <input list="searchableUsers" id="firstplace" placeholder="Select a player" />
             </div>
                 <br>
             <div id="2" onchange="updateState()">
@@ -45,9 +43,7 @@
                     <option value="3">3</option>
                     <option value="4">4</option>
                 </select>
-                <select  name="playerlist" list="players" id="secondplace">
-                    <option value="none" selected disabled hidden>Select a player</option>
-                </select>
+                <input list="searchableUsers" id="secondplace" placeholder="Select a player" />
             </div>
                 <br>
             <div id="3" onchange="updateState()">
@@ -59,9 +55,7 @@
                     <option value="3">3</option>
                     <option value="4">4</option>
                 </select>
-                <select  name="playerlist" list="players" id="thirdplace">
-                    <option value="none" selected disabled hidden>(None)</option>
-                </select>
+                <input list="searchableUsers" id="thirdplace" placeholder="(None)" />
             </div>
                 <br>
             <div id="4" onchange="updateState()">
@@ -73,16 +67,10 @@
                     <option value="3">3</option>
                     <option value="4">4</option>
                 </select>
-                <select  name="playerlist" list="players" id="fourthplace">
-                    <option value="none" selected disabled hidden>(None)</option>
-                </select>
+                <input list="searchableUsers" id="fourthplace" placeholder="(None)" />
             </div>
             
-            <datalist id="placements">
-              <option value="1">
-              <option value="2">
-              <option value="3">
-              <option value="4">
+            <datalist id="searchableUsers">
             </datalist>
 
         </form>


### PR DESCRIPTION
With the list growing, being able to type in a few letters and narrow the list down to a few people helps speed up the selection process, especially for users whose names are alphabetically near the bottom of the list

## Details
* Use `<datalist>` HTML5 component to achive this, which allows `<input>` commands to double as both drop-down selector lists and auto-complete text inputs
* If using a datalist, we can no longer use the `data-userid` attribute on the `<option>` component to store the numerical user ID.
  * Thus, create a dictionary of user name-to-ID when loading the user names, and use it to lookup which numerical ID should be used in the bot command.
* Addresses repo issue:  https://github.com/mr309/MGSR-TeamUp/issues/6

## Demo
https://user-images.githubusercontent.com/96504438/149639371-805dc392-b73a-4daf-bdda-e28e0365087e.mov


