### PR TITLE
Enable Support for Up 3 or 4 Players in Single Record Command

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -154,10 +154,12 @@ function renderCommands(state) {
 
       const commandID = p1.userID + "_" + p2.userID;
 
-      let p1BotPlace = "1";
+      /*let p1BotPlace = "1";
       let p2BotPlace = "2";
+      let p3BotPlace = "3";
+      let p4BotPlace = "4";
 
-      /*if (p1.place == p2.place) {
+      if (p1.place == p2.place) {
         p2BotPlace = "1";
       }*/
 
@@ -171,25 +173,35 @@ function renderCommands(state) {
         " (" +
         p1.userName +
         ")" +
-        (p1BotPlace == p2BotPlace ? " ties " : " defeats ") +
+        ", " +
         p2.place +
         getPlaceSuffix(p2.place) +
         " (" +
         p2.userName +
+        "), " +
+        p3.place +
+        getPlaceSuffix(p3.place) +
+        " (" +
+        p3.userName +
+        "), " +
+        p4.place +
+        getPlaceSuffix(p4.place) +
+        " (" +
+        p4.userName +
         ")";
       let copyButton = document.createElement("button");
       copyButton.setAttribute("onclick", "copyClipboard('" + commandID + "')");
-      copyButton.style = "margin-left: 4px;";
+      copyButton.style = "margin-right: 4px;";
       copyButton.innerHTML = "Copy";
-      resultHeader.appendChild(resultDesc);
       resultHeader.appendChild(copyButton);
+      resultHeader.appendChild(resultDesc);
       document.getElementById("MultiResultsArea").appendChild(resultHeader);
 
-      let resultCommand = document.createElement("input");
+      let resultCommand = document.createElement("textarea");
       resultCommand.setAttribute("id", commandID);
       resultCommand.setAttribute("class", "command");
       //need to add `<@!${ }>` around usernames, for proper command in Discord.
-      const matchResultSyntax = ` #${p1BotPlace} <@!${p1.userID}> #${p2BotPlace} <@!${p2.userID}>`;
+      const matchResultSyntax = ` #${p1.place} <@!${p1.userID}> #${p2.place} <@!${p2.userID}> #${p3.place} <@!${p3.userID}> #${p4.place} <@!${p4.userID}>`;
       resultCommand.value = defaultCommand + matchResultSyntax;
       document.getElementById("MultiResultsArea").appendChild(resultCommand);
     }

--- a/js/app.js
+++ b/js/app.js
@@ -30,7 +30,7 @@ const userIds = (async () => {
     data = await getUsers(LEADERBOARD_NAME);
   } catch (ex) {
     // Simulate network loading time, .75 seconds
-    await new Promise(sleep => setTimeout(sleep, 750));
+    await new Promise((sleep) => setTimeout(sleep, 750));
 
     // Makes it possible to test changes locally before pushing to main branch
     data = [
@@ -63,7 +63,7 @@ function UserSort(userIdData) {
     }
     return 0;
   });
-  userIdData = userIdData.unshift(["TagMe", "(New Competitor)"]);
+  userIdData = userIdData.unshift(["TagMe", "[New Competitor]"]);
 }
 
 const searchableList = document.getElementById("searchableUsers");
@@ -145,8 +145,6 @@ function renderCommands(state) {
   let pairList = pairings.map((e) => {
     const p1 = e[0];
     const p2 = e[1];
-    const p3 = e[2];
-    const p4 = e[3];
     if (p1.place != "" && p1.userID != null && p2.place != "" && p2.userID != null) {
       // Only include results in output if it is for a valid pairing
       // Which means, the pairing has a place and user selected
@@ -163,31 +161,32 @@ function renderCommands(state) {
       }*/
 
       hasEnoughSelections = true;
+
+      let matchSize = 2;
+      const p3 = e[2];
+      if (p3.place != "" && p3.userID != null) {
+        matchSize = 3;
+      }
+
+      const p4 = e[3];
+      if (p4.place != "" && p4.userID != null) {
+        matchSize = 4;
+      }
+
       let resultHeader = document.createElement("div");
       let resultDesc = document.createElement("span");
       resultDesc.style = "font-size: 0.75em; font-weight: bold;";
-      resultDesc.innerHTML =
-        p1.place +
-        getPlaceSuffix(p1.place) +
-        " (" +
-        p1.userName +
-        ")" +
-        ", " +
-        p2.place +
-        getPlaceSuffix(p2.place) +
-        " (" +
-        p2.userName +
-        "), " +
-        p3.place +
-        getPlaceSuffix(p3.place) +
-        " (" +
-        p3.userName +
-        "), " +
-        p4.place +
-        getPlaceSuffix(p4.place) +
-        " (" +
-        p4.userName +
-        ")";
+      const resultSummaryParts = []
+      resultSummaryParts.push(p1.place + getPlaceSuffix(p1.place) + " (" + p1.userName + ")");
+      resultSummaryParts.push(p2.place + getPlaceSuffix(p2.place) + " (" + p2.userName + ")");
+      if (matchSize >= 3) {
+        resultSummaryParts.push(p3.place + getPlaceSuffix(p3.place) + " (" + p3.userName + ")");
+      }
+      if (matchSize == 4) {
+        resultSummaryParts.push(p4.place + getPlaceSuffix(p4.place) + " (" + p4.userName + ")");
+      }
+      resultDesc.innerHTML = resultSummaryParts.join(", ");
+
       let copyButton = document.createElement("button");
       copyButton.setAttribute("onclick", "copyClipboard('" + commandID + "')");
       copyButton.style = "margin-right: 4px;";
@@ -196,11 +195,19 @@ function renderCommands(state) {
       resultHeader.appendChild(resultDesc);
       document.getElementById("MultiResultsArea").appendChild(resultHeader);
 
-      let resultCommand = document.createElement("textarea");
+      let resultCommand = document.createElement("input");
       resultCommand.setAttribute("id", commandID);
       resultCommand.setAttribute("class", "command");
+
       //need to add `<@!${ }>` around usernames, for proper command in Discord.
-      const matchResultSyntax = ` #${p1.place} <@!${p1.userID}> #${p2.place} <@!${p2.userID}> #${p3.place} <@!${p3.userID}> #${p4.place} <@!${p4.userID}>`;
+      let matchResultSyntax = ` #${p1.place} <@!${p1.userID}> #${p2.place} <@!${p2.userID}>`;
+      if (matchSize >= 3) {
+        matchResultSyntax = matchResultSyntax + ` #${p3.place} <@!${p3.userID}>`;
+      }
+      if (matchSize == 4) {
+        matchResultSyntax = matchResultSyntax + ` #${p4.place} <@!${p4.userID}>`;
+      }
+
       resultCommand.value = defaultCommand + matchResultSyntax;
       document.getElementById("MultiResultsArea").appendChild(resultCommand);
     }

--- a/js/app.js
+++ b/js/app.js
@@ -29,7 +29,7 @@ const userIds = (async () => {
     data = await getUsers(LEADERBOARD_NAME);
   } catch (ex) {
     // Simulate network loading time, 1.5 seconds
-    await new Promise(sleep => setTimeout(sleep, 1500));
+    await new Promise((sleep) => setTimeout(sleep, 1500));
 
     // Makes it possible to test changes locally before pushing to main branch
     data = [
@@ -130,20 +130,24 @@ function updateState() {
 }
 
 function renderCommands(state) {
-  // Need to output the individual commands for each pairing
+  // Used to have to output the individual commands for each pairing
   // For a 1,2,3,4 match, this would be 6 commands
   // 1: 1v2, 1v3, 1v4; 2: 2v3, 2v4; 3: 3v4
   // For a 1,2,3 (or 1,1,3), it would be 3 commands
   // for a 1,2 (or 1,1), just 1 command
+  // No longer necessary with 1/20/22 TeamUp Update
 
   // First, clear any existing elements produced on a previous click
   document.getElementById("MultiResultsArea").innerHTML = "";
 
   let pairings = getPairings(state);
   let hasEnoughSelections = false;
+  console.log(pairings);
   let pairList = pairings.map((e) => {
     const p1 = e[0];
     const p2 = e[1];
+    const p3 = e[2];
+    const p4 = e[3];
     if (p1.place != "" && p1.userID != null && p2.place != "" && p2.userID != null) {
       // Only include results in output if it is for a valid pairing
       // Which means, the pairing has a place and user selected
@@ -152,9 +156,10 @@ function renderCommands(state) {
 
       let p1BotPlace = "1";
       let p2BotPlace = "2";
-      if (p1.place == p2.place) {
+
+      /*if (p1.place == p2.place) {
         p2BotPlace = "1";
-      }
+      }*/
 
       hasEnoughSelections = true;
       let resultHeader = document.createElement("div");
@@ -196,7 +201,9 @@ function renderCommands(state) {
   }
 }
 
-function getPairings(o) {
+// Obsolete after 1/20/22 TeamUp Update. No longer need pairings.
+// Just need to do simple '#1 ... #2 ... #3 ... #4 ... command'
+/* function getPairings(o) {
   return [
     [o[1], o[2]],
     [o[1], o[3]],
@@ -205,6 +212,11 @@ function getPairings(o) {
     [o[2], o[4]],
     [o[3], o[4]],
   ];
+}
+*/
+
+function getPairings(o) {
+  return [[o[1], o[2], o[3], o[4]]];
 }
 
 function getPlaceSuffix(placeNumber) {


### PR DESCRIPTION
## Summary
* Enable the tool to work with the new command syntax
* The only thing I changed from your initial coding Chippy is that both the description like "1st (abc), 2nd (def)" as well as the bot command itself will now only populate the 3rd and 4th spots if the 3rd and/or 4th user selectors/placements have been specified

## Demo
https://user-images.githubusercontent.com/96504438/150627470-a0ebfbc2-7740-4e08-9542-4a1881a0caea.mov